### PR TITLE
Change max precision so dumps work

### DIFF
--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -23,7 +23,7 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
                  const FeatureMap& fmap,
                  int nid, int depth, int add_comma,
                  bool with_stats, std::string format) {
-  int float_max_precision = std::numeric_limits<bst_float>::max_digits10;
+  int float_max_precision = std::numeric_limits<float>::max_digits10;
   if (format == "json") {
     if (add_comma) {
       fo << ",";


### PR DESCRIPTION
Numbers like `20180201` otherwise become `2.01802e+007`